### PR TITLE
Update inspect-browser.ts

### DIFF
--- a/src/inspect-browser.ts
+++ b/src/inspect-browser.ts
@@ -2,7 +2,7 @@ import * as util from 'util'
 import spok from './spok'
 
 // terminal colors won't show properly in the browser
-spok.color = false
+if(spok) spok.color = false;
 
 export default function inspect(obj: any, color: boolean) {
   return util.inspect(obj, false, 5, color)


### PR DESCRIPTION
Fix issue when spok is undefined in browser

Fixes #4 

ideally, there shouldn't be mutations done in this line, but I'm not familiar enough with the code to rewrite it without it.

for context:

with ES modules the export order is not always guaranteed so it's not safe to mutate objects that you import as they might be undefined depending on the dependency graph.

more info here: https://stackoverflow.com/questions/46601580/es6-modules-import-is-undefined/46603044