### PR TITLE
fix(docs/README): document .default for cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Checks a given object against a given set of specifications to keep you from wri
 
 ```js
 var test = require('tape')
-var spok = require('spok')
+var spok = require('spok').default
 
 // this would be returned from a function you are testing
 var object = {


### PR DESCRIPTION
Signed-off-by: Robert Jefe Lindstaedt <robert.lindstaedt@gmail.com>

Locally, and likely due to `allowSyntheticDefaultImports = true`, with a Node16 setup one would need to `.default` afaict. Else, type and module resolution works as expected.