### PR TITLE
feat: allow force color override

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Spok support this out of the box as follows:
 
 See [./example/node-test.js](./example/node-test.js) and [./example/node-test-nested.js](./example/node-test-nested.js)for a full examples.
 
+### Colors 
+
+_spok_ detects if colors should be used in the output in order to avoid breaking TAP
+compatibility when needed as follows:
+
+- if `FORCE_COLOR` env var is set to `1|true` colors are ALWAYS
+- if `NO_COLOR` env var is set to `1|true` colors are NEVER used
+- if tests are executed via `node --test mytest.js` and `FORCE_COLOR` is not set then colorse are disabled
+- if tests are executed via `node mytest.js` and `NO_COLOR` is not set then colors are enabled
+
+
 ## Tap/Tape
 
 - tap and tape provide a `t` which mirrors the `assert` module and also prints results and the

--- a/src/spok.ts
+++ b/src/spok.ts
@@ -11,7 +11,7 @@ import {
   SpokFunctionAny,
 } from './types'
 import { isTestContext, TestContext } from './types-internal'
-import { isRunningAsTestChildProcess } from './utils'
+import { isForcingColor, isRunningAsTestChildProcess } from './utils'
 
 export * from './types'
 import { chaiExpect } from './adapter-chai-expect'
@@ -23,9 +23,13 @@ import { chaiExpect } from './adapter-chai-expect'
 // We hope that this resolves before too many colorless diagnostics were printed.
 let disableColor = true
 ;(function() {
-  isRunningAsTestChildProcess().then((x) => {
-    disableColor = x
-  })
+  if (isForcingColor()) {
+    disableColor = false
+  } else {
+    isRunningAsTestChildProcess().then((x) => {
+      disableColor = x
+    })
+  }
 })()
 
 // only recurse into arrays if they contain actual specs or objects

--- a/src/utils-browser.ts
+++ b/src/utils-browser.ts
@@ -1,3 +1,4 @@
+export function isForcingColor() { return false }
 export async function isRunningAsTestChildProcess() {
   return false
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,12 @@
 import find from 'find-process'
 
+// Allow the user to override detection if we can use colors
+const forceColorEnv = process.env.FORCE_COLOR
+export function isForcingColor() {
+  if (forceColorEnv === '1' || forceColorEnv === 'true') return false
+  return true
+}
+
 export async function isRunningAsTestChildProcess() {
   if (process.ppid == null) return false
   const procs = await find('pid', process.ppid)


### PR DESCRIPTION
## Summary

In some cases detection for colors maybe too slow so we allow the user to override it with
`FORCE_COLOR`.
